### PR TITLE
Show full record in list for grass modules

### DIFF
--- a/actinia_module_plugin/api/modules/combined.py
+++ b/actinia_module_plugin/api/modules/combined.py
@@ -29,7 +29,7 @@ __copyright__ = "Copyright 2019, mundialis"
 __maintainer__ = "Carmen Tawalika"
 
 
-from flask import jsonify, make_response
+from flask import jsonify, make_response, request
 from flask_restful_swagger_2 import swagger
 from actinia_core.resources.resource_base import ResourceBase
 
@@ -43,6 +43,7 @@ from actinia_module_plugin.core.modules.actinia_common import \
      createActiniaModule
 from actinia_module_plugin.core.modules.grass import createModuleList
 from actinia_module_plugin.core.modules.grass import createGrassModule
+from actinia_module_plugin.core.modules.grass import createFullModuleList
 from actinia_module_plugin.model.modules import ModuleList
 from actinia_module_plugin.model.responseModels import \
     SimpleStatusCodeResponseModel
@@ -58,6 +59,12 @@ class ListVirtualModules(ResourceBase):
         """
 
         grass_list = createModuleList(self)
+        grass_list = filter(grass_list)
+
+        if 'record' in request.args:
+            if request.args['record'] == "full":
+                grass_list = createFullModuleList(self, grass_list)
+
         pc_list_fs = createProcessChainTemplateListFromFileSystem()
         pc_list_redis = createProcessChainTemplateListFromRedis()
         module_list = grass_list + pc_list_fs + pc_list_redis

--- a/actinia_module_plugin/api/modules/grass.py
+++ b/actinia_module_plugin/api/modules/grass.py
@@ -28,7 +28,7 @@ __copyright__ = "Copyright 2019, mundialis"
 __maintainer__ = "Anika Bettge, Carmen Tawalika"
 
 
-from flask import jsonify, make_response
+from flask import jsonify, make_response, request
 from flask_restful_swagger_2 import swagger
 from actinia_core.resources.resource_base import ResourceBase
 
@@ -36,6 +36,7 @@ from actinia_module_plugin.apidocs import modules
 from actinia_module_plugin.core.filter import filter
 from actinia_module_plugin.core.modules.grass import createModuleList
 from actinia_module_plugin.core.modules.grass import createGrassModule
+from actinia_module_plugin.core.modules.grass import createFullModuleList
 from actinia_module_plugin.model.modules import ModuleList
 from actinia_module_plugin.model.responseModels import \
      SimpleStatusCodeResponseModel
@@ -52,6 +53,10 @@ class ListModules(ResourceBase):
 
         module_list = createModuleList(self)
         module_list = filter(module_list)
+
+        if 'record' in request.args:
+            if request.args['record'] == "full":
+                module_list = createFullModuleList(self, module_list)
 
         return make_response(jsonify(ModuleList(
             status="success",

--- a/actinia_module_plugin/apidocs/modules.py
+++ b/actinia_module_plugin/apidocs/modules.py
@@ -51,6 +51,24 @@ listModules_get_docs = {
            "name": "category",
            "type": "string",
            "description": "Another filter for categories"
+       },
+       {
+           "in": "path",
+           "name": "family",
+           "type": "string",
+           "description": "Type of GRASS GIS module",
+           "enum": ["d", "db", "g", "i", "m", "ps", "r", "r3",
+                    "t", "test", "v"]
+       },
+       {
+           "in": "path",
+           "name": "record",
+           "type": "string",
+           "description": "If set to 'full', all information about the "
+                          "returned modules are given like in the single "
+                          "module description. Depending on active cache, "
+                          "this response might run into a timeout. A filter "
+                          "can prevent this."
        }
     ],
     'responses': {

--- a/actinia_module_plugin/core/filter.py
+++ b/actinia_module_plugin/core/filter.py
@@ -28,6 +28,7 @@ __maintainer__ = "Carmen Tawalika"
 from flask import request
 
 
+global family
 global tag
 global category
 
@@ -35,6 +36,15 @@ global category
 def filter(full_list):
 
     filter_list = full_list
+
+    # INFO: record=full is directly parsed in api method
+
+    if 'family' in request.args:
+        global family
+        family = request.args['family']
+        # d, db, g, i, m, ps, r, r3, t, test, v
+        val = family + '.'
+        filter_list = [i for i in filter_list if str(i['id']).startswith(val)]
 
     if 'tag' in request.args:
         global tag

--- a/actinia_module_plugin/core/modules/grass.py
+++ b/actinia_module_plugin/core/modules/grass.py
@@ -34,6 +34,7 @@ from actinia_core.resources.common.response_models import \
 from actinia_module_plugin.core.modules.processor import run_process_chain
 from actinia_module_plugin.core.modules.parser import ParseInterfaceDescription
 from actinia_module_plugin.model.modules import Module
+from actinia_module_plugin.resources.logging import log
 
 
 def createModuleList(self):
@@ -87,3 +88,30 @@ def createGrassModule(self, module):
     grass_module = ParseInterfaceDescription(xml_string)
 
     return grass_module
+
+
+def createFullModuleList(self, module_list):
+    # all_modules = createModuleList(self)
+    pc = {"version": 1,
+          "list": []}
+
+    process_chain_items = []
+    count = 1
+    for module in module_list:
+        process_chain_items.append(
+            {"id": count, "module": module['id'],
+             "interface-description": True})
+        count = count + 1
+
+    pc['list'] = process_chain_items
+    response = run_process_chain(self, pc)
+
+    detailed_module_list = []
+    for desc in response['process_log']:
+        try:
+            grass_module = ParseInterfaceDescription(desc['stdout'])
+            detailed_module_list.append(grass_module)
+        except Exception:
+            log.error('error parsing module %s' % desc['executable'])
+
+    return detailed_module_list

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -131,6 +131,21 @@ class VirtualModulesTest(ActiniaTestCase):
         # installed GRASS GIS Addons
         assert len(resp.json['processes']) == 7
 
+    def test_filter_list_modules_get_6(self):
+        """Test HTTP GET /grass_modules with filter"""
+        respStatusCode = 200
+        resp = self.app.get(URL_PREFIX + '/modules?record=full&family=ps',
+                            headers=self.user_auth_header)
+
+        assert type(resp) is Response
+        assert resp.status_code == respStatusCode
+        assert hasattr(resp, 'json')
+        # WARNING: this depends on existing GRASS GIS modules and possible
+        # installed GRASS GIS Addons
+        assert len(resp.json['processes']) == 1
+        assert resp.json['processes'][0]['categories'] != 0
+        assert resp.json['processes'][0]['parameters'] != 0
+
 
 for i in someVirtualModules:
     """Test HTTP GET /modules/<module> for file based templates and GRASS GIS

--- a/tests/test_modules_grass.py
+++ b/tests/test_modules_grass.py
@@ -74,6 +74,37 @@ class GmodulesTest(ActiniaTestCase):
         # installed GRASS GIS Addons
         assert len(resp.json['processes']) == 2
 
+    def test_filter_list_modules_get_2(self):
+        """Test HTTP GET /grass_modules with filter"""
+        respStatusCode = 200
+        url_path = '/grass_modules?record=full&family=ps'
+        resp = self.app.get(URL_PREFIX + url_path,
+                            headers=self.user_auth_header)
+
+        assert type(resp) is Response
+        assert resp.status_code == respStatusCode
+        assert hasattr(resp, 'json')
+        # WARNING: this depends on existing GRASS GIS modules and possible
+        # installed GRASS GIS Addons
+        assert len(resp.json['processes']) == 1
+        assert resp.json['processes'][0]['categories'] != 0
+        assert resp.json['processes'][0]['parameters'] != 0
+
+    def test_filter_list_modules_get_3(self):
+        """Test HTTP GET /grass_modules with filter"""
+        respStatusCode = 200
+        resp = self.app.get(URL_PREFIX + '/grass_modules?family=test',
+                            headers=self.user_auth_header)
+
+        assert type(resp) is Response
+        assert resp.status_code == respStatusCode
+        assert hasattr(resp, 'json')
+        # WARNING: this depends on existing GRASS GIS modules and possible
+        # installed GRASS GIS Addons
+        assert len(resp.json['processes']) == 2
+        assert resp.json['processes'][0]['categories'] != 0
+        assert hasattr(resp.json['processes'][0], 'parameters') is False
+
 
 for i in someGrassModules:
     """Test HTTP GET /grass_modules/<module> for GRASS GIS modules in loop


### PR DESCRIPTION
This PR enhances the module self-description for GRASS GIS modules in `/grass_modules` and `/modules` endpoint:
* filter by family
* show full record instead of only "category", "id" and "description"
