### PR TITLE
Adjust to actinia-core updates

### DIFF
--- a/actinia_module_plugin/api/processing.py
+++ b/actinia_module_plugin/api/processing.py
@@ -96,6 +96,7 @@ def log_error_to_resource_logger(self, msg, rdc):
     self.resource_logger.commit(
         user_id=self.user_id,
         resource_id=self.resource_id,
+        iteration=1,
         document=data,
         expiration=rdc.config.REDIS_RESOURCE_EXPIRE_TIME
     )

--- a/actinia_module_plugin/core/modules/grass.py
+++ b/actinia_module_plugin/core/modules/grass.py
@@ -59,8 +59,8 @@ def createModuleList(self):
         message=''
     )
     self.resource_logger.commit(
-        user_id=self.user_id, resource_id=self.resource_id, document=data,
-        expiration=1)
+        user_id=self.user_id, resource_id=self.resource_id, iteration=1,
+        document=data, expiration=1)
 
     module_list = []
     for data in j_data:
@@ -99,7 +99,7 @@ def createFullModuleList(self, module_list):
     count = 1
     for module in module_list:
         process_chain_items.append(
-            {"id": count, "module": module['id'],
+            {"id": str(count), "module": module['id'],
              "interface-description": True})
         count = count + 1
 


### PR DESCRIPTION
After actinia-core release 0.99.28, the iteration is needed as argument for `self.resource_logger.commit` method and 'The attribute "id" must be a string, but was "<class \'int\'>"'. 
This PR gets along with this.