### PR TITLE
Move actinia_core imports

### DIFF
--- a/actinia_module_plugin/api/actinia_templates.py
+++ b/actinia_module_plugin/api/actinia_templates.py
@@ -33,7 +33,7 @@ __maintainer__ = "Carmen Tawalika"
 
 from flask import jsonify, make_response, request
 from flask_restful_swagger_2 import swagger
-from actinia_core.resources.resource_base import ResourceBase
+from actinia_core.rest.resource_base import ResourceBase
 
 from actinia_module_plugin.apidocs import templates
 from actinia_module_plugin.core.templates.user_templates import readAll

--- a/actinia_module_plugin/api/modules/actinia.py
+++ b/actinia_module_plugin/api/modules/actinia.py
@@ -32,7 +32,7 @@ __maintainer__ = "Carmen Tawalika"
 from flask import jsonify, make_response
 from flask_restful_swagger_2 import swagger
 from flask_restful import Resource
-from actinia_core.resources.resource_base import ResourceBase
+from actinia_core.rest.resource_base import ResourceBase
 
 from actinia_module_plugin.apidocs import modules
 from actinia_module_plugin.core.filter import filter

--- a/actinia_module_plugin/api/modules/combined.py
+++ b/actinia_module_plugin/api/modules/combined.py
@@ -31,7 +31,7 @@ __maintainer__ = "Carmen Tawalika"
 
 from flask import jsonify, make_response, request
 from flask_restful_swagger_2 import swagger
-from actinia_core.resources.resource_base import ResourceBase
+from actinia_core.rest.resource_base import ResourceBase
 
 from actinia_module_plugin.apidocs import modules
 from actinia_module_plugin.core.filter import filter

--- a/actinia_module_plugin/api/modules/grass.py
+++ b/actinia_module_plugin/api/modules/grass.py
@@ -30,7 +30,7 @@ __maintainer__ = "Anika Bettge, Carmen Tawalika"
 
 from flask import jsonify, make_response, request
 from flask_restful_swagger_2 import swagger
-from actinia_core.resources.resource_base import ResourceBase
+from actinia_core.rest.resource_base import ResourceBase
 
 from actinia_module_plugin.apidocs import modules
 from actinia_module_plugin.core.filter import filter

--- a/actinia_module_plugin/api/processing.py
+++ b/actinia_module_plugin/api/processing.py
@@ -54,7 +54,7 @@ import pickle
 from flask import jsonify, make_response
 from flask_restful_swagger_2 import swagger
 from actinia_core.core.common.redis_interface import enqueue_job
-from actinia_core.core.common.response_models import \
+from actinia_core.models.response_models import \
      create_response_from_model
 from actinia_core.rest.ephemeral_processing_with_export import \
      start_job as start_job_ephemeral_processing_with_export, \

--- a/actinia_module_plugin/api/processing.py
+++ b/actinia_module_plugin/api/processing.py
@@ -53,16 +53,16 @@ import pickle
 
 from flask import jsonify, make_response
 from flask_restful_swagger_2 import swagger
-from actinia_core.resources.common.redis_interface import enqueue_job
-from actinia_core.resources.common.response_models import \
+from actinia_core.core.common.redis_interface import enqueue_job
+from actinia_core.core.common.response_models import \
      create_response_from_model
-from actinia_core.resources.ephemeral_processing_with_export import \
+from actinia_core.rest.ephemeral_processing_with_export import \
      start_job as start_job_ephemeral_processing_with_export, \
      SCHEMA_DOC as SCHEMA_DOC_EPHEMERAL_PROCESSING_WITH_EXPORT
-from actinia_core.resources.persistent_processing import \
+from actinia_core.rest.persistent_processing import \
      start_job as start_job_persistent_processing, \
      SCHEMA_DOC as SCHEMA_DOC_PERSISTENT_PROCESSING
-from actinia_core.resources.resource_base import ResourceBase
+from actinia_core.rest.resource_base import ResourceBase
 
 from actinia_module_plugin.core.modules.actinia_global_templates import \
      createProcessChainTemplateListFromFileSystem

--- a/actinia_module_plugin/apidocs/templates.py
+++ b/actinia_module_plugin/apidocs/templates.py
@@ -28,7 +28,7 @@ import os
 import json
 
 from flask_restful_swagger_2 import Schema
-from actinia_core.resources.common.process_chain import GrassModule
+from actinia_core.core.common.process_chain import GrassModule
 
 from actinia_module_plugin.model.responseModels import \
      SimpleStatusCodeResponseModel

--- a/actinia_module_plugin/core/modules/grass.py
+++ b/actinia_module_plugin/core/modules/grass.py
@@ -28,7 +28,7 @@ __maintainer__ = "Anika Bettge, Carmen Tawalika"
 import json
 import time
 
-from actinia_core.resources.common.response_models import \
+from actinia_core.core.common.response_models import \
      create_response_from_model
 
 from actinia_module_plugin.core.modules.processor import run_process_chain

--- a/actinia_module_plugin/core/modules/grass.py
+++ b/actinia_module_plugin/core/modules/grass.py
@@ -28,7 +28,7 @@ __maintainer__ = "Anika Bettge, Carmen Tawalika"
 import json
 import time
 
-from actinia_core.core.common.response_models import \
+from actinia_core.models.response_models import \
      create_response_from_model
 
 from actinia_module_plugin.core.modules.processor import run_process_chain

--- a/actinia_module_plugin/core/modules/processor.py
+++ b/actinia_module_plugin/core/modules/processor.py
@@ -54,7 +54,7 @@ import uuid
 
 from actinia_core.core.common.config import global_config
 from actinia_core.rest.ephemeral_processing import EphemeralProcessing
-from actinia_core.core.common.response_models import \
+from actinia_core.models.response_models import \
      StringListProcessingResultResponseModel
 
 from actinia_module_plugin.core.common import start_job

--- a/actinia_module_plugin/core/modules/processor.py
+++ b/actinia_module_plugin/core/modules/processor.py
@@ -52,9 +52,9 @@ import shutil
 import pickle
 import uuid
 
-from actinia_core.resources.common.config import global_config
-from actinia_core.resources.ephemeral_processing import EphemeralProcessing
-from actinia_core.resources.common.response_models import \
+from actinia_core.core.common.config import global_config
+from actinia_core.rest.ephemeral_processing import EphemeralProcessing
+from actinia_core.core.common.response_models import \
      StringListProcessingResultResponseModel
 
 from actinia_module_plugin.core.common import start_job

--- a/actinia_module_plugin/core/templates/user_templates.py
+++ b/actinia_module_plugin/core/templates/user_templates.py
@@ -26,7 +26,7 @@ __copyright__ = "Copyright 2021, mundialis"
 __maintainer__ = "Carmen Tawalika"
 
 
-from actinia_core.resources.common.config import Configuration
+from actinia_core.core.common.config import Configuration
 
 from actinia_module_plugin.core.templates.user_templates_redis_interface \
      import redis_actinia_template_interface

--- a/actinia_module_plugin/core/templates/user_templates_redis_interface.py
+++ b/actinia_module_plugin/core/templates/user_templates_redis_interface.py
@@ -28,7 +28,7 @@ __maintainer__ = "Carmen Tawalika"
 
 import pickle
 
-from actinia_core.resources.common.redis_base import RedisBaseInterface
+from actinia_core.core.common.redis_base import RedisBaseInterface
 
 
 class RedisActiniaTemplateInterface(RedisBaseInterface):

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -26,7 +26,7 @@ __copyright__ = "Copyright 2021, mundialis"
 
 from flask import Response
 
-from actinia_core.resources.common.app import URL_PREFIX
+from actinia_core.core.common.app import URL_PREFIX
 
 from testsuite import ActiniaTestCase, compare_module_to_file
 

--- a/tests/test_modules_actinia_global.py
+++ b/tests/test_modules_actinia_global.py
@@ -26,7 +26,7 @@ __copyright__ = "Copyright 2021, mundialis"
 
 from flask import Response
 
-from actinia_core.resources.common.app import URL_PREFIX
+from actinia_core.core.common.app import URL_PREFIX
 
 from testsuite import ActiniaTestCase, compare_module_to_file
 

--- a/tests/test_modules_actinia_user.py
+++ b/tests/test_modules_actinia_user.py
@@ -26,7 +26,7 @@ __copyright__ = "Copyright 2021, mundialis"
 import json
 from flask import Response
 
-from actinia_core.resources.common.app import URL_PREFIX
+from actinia_core.core.common.app import URL_PREFIX
 
 from testsuite import ActiniaTestCase, import_user_template, \
      delete_user_template

--- a/tests/test_modules_grass.py
+++ b/tests/test_modules_grass.py
@@ -28,7 +28,7 @@ __copyright__ = "Copyright 2021, mundialis"
 
 from flask import Response
 
-from actinia_core.resources.common.app import URL_PREFIX
+from actinia_core.core.common.app import URL_PREFIX
 
 from testsuite import ActiniaTestCase, compare_module_to_file
 

--- a/tests/test_processing_global.py
+++ b/tests/test_processing_global.py
@@ -27,7 +27,7 @@ __copyright__ = "Copyright 2021, mundialis"
 from flask import Response
 import json
 
-from actinia_core.resources.common.app import URL_PREFIX
+from actinia_core.core.common.app import URL_PREFIX
 
 
 from testsuite import ActiniaTestCase, check_started_process

--- a/tests/test_processing_user.py
+++ b/tests/test_processing_user.py
@@ -27,7 +27,7 @@ __copyright__ = "Copyright 2021, mundialis"
 from flask import Response
 import json
 
-from actinia_core.resources.common.app import URL_PREFIX
+from actinia_core.core.common.app import URL_PREFIX
 
 from testsuite import ActiniaTestCase, import_user_template, \
      delete_user_template,  check_started_process

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -28,7 +28,7 @@ from flask import Response
 import json
 import uuid
 
-from actinia_core.resources.common.app import URL_PREFIX
+from actinia_core.core.common.app import URL_PREFIX
 
 from testsuite import ActiniaTestCase
 

--- a/tests/testsuite.py
+++ b/tests/testsuite.py
@@ -55,11 +55,11 @@ import pwgen
 from werkzeug.datastructures import Headers
 
 from actinia_core.endpoints import create_endpoints
-from actinia_core.resources.common import redis_interface
-from actinia_core.resources.common.app import flask_app, URL_PREFIX
-from actinia_core.resources.common.config import global_config
-from actinia_core.resources.common.user import ActiniaUser
-from actinia_core.resources.common.response_models import \
+from actinia_core.core.common import redis_interface
+from actinia_core.core.common.app import flask_app, URL_PREFIX
+from actinia_core.core.common.config import global_config
+from actinia_core.core.common.user import ActiniaUser
+from actinia_core.models.response_models import \
      ProcessingResponseModel
 
 
@@ -110,7 +110,7 @@ class ActiniaTestCase(unittest.TestCase):
             process_time_limit=4, accessible_datasets=accessible_datasets)
 
         # # create process queue
-        # from actinia_core.resources.common.process_queue import \
+        # from actinia_core.core.common.process_queue import \
         #    create_process_queue
         # create_process_queue(config=global_config)
 


### PR DESCRIPTION
As the modules follow a new folder structure in actinia_core, the imports needed to be adjusted.
See https://github.com/mundialis/actinia_core/pull/221

* modules from `actinia_core.resources.common` changed to `actinia_core.core.common`
* modules from `actinia_core.resources` changed to `actinia_core.rest`
* response_models moved to `actinia_core.models.response_models`