### PR TITLE
Add redis cache for grass modules

### DIFF
--- a/actinia_module_plugin/apidocs/modules.py
+++ b/actinia_module_plugin/apidocs/modules.py
@@ -97,7 +97,9 @@ describeModule_get_docs = {
         }
     ],
     'description': 'Get the description of a module. '
-                   'Minimum required user role: user.',
+                   'Minimum required user role: user.'
+                   'Can be also used to reload cache for a certain module'
+                   'for the full module description in listModules.',
     'responses': {
         '200': {
             'description': 'This response returns a description of a module.',

--- a/actinia_module_plugin/core/modules/actinia_common.py
+++ b/actinia_module_plugin/core/modules/actinia_common.py
@@ -179,6 +179,7 @@ class PlaceholderCollector(object):
         item_key = str(self.count)
         pc_item = {item_key: {"module": vp.module,
                               "interface-description": True}}
+        # TODO make use of module in redis cache if exists
         response = run_process_chain(self.resourceBaseSelf, pc_item)
         xml_strings = response['process_log']
         self.count = self.count + 1

--- a/actinia_module_plugin/core/modules/grass_modules_redis_interface.py
+++ b/actinia_module_plugin/core/modules/grass_modules_redis_interface.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Copyright (c) 2018-2021 mundialis GmbH & Co. KG
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
+GRASS GIS module cache in redis
+Redis interface
+"""
+
+__license__ = "Apache-2.0"
+__author__ = "Carmen Tawalika"
+__copyright__ = "Copyright 2021, mundialis"
+__maintainer__ = "Carmen Tawalika"
+
+
+import pickle
+
+from actinia_core.core.common.redis_base import RedisBaseInterface
+
+
+class RedisActiniaGrassModuleInterface(RedisBaseInterface):
+    """The Redis GRASS GIS module database interface
+
+    A single GRASS GIS module is stored as Hash with:
+        - GRASS GIS module name that must be unique
+        - GRASS GIS module dictionary
+
+    In addition is the GRASS GIS module name saved in a hash that contains all
+    GRASS GIS module names.
+    """
+
+    grass_module_id_hash_prefix = "GRASS-MODULE-ID-HASH-PREFIX::"
+    grass_module_id_db = "GRASS-MODULE-ID-DATABASE"
+
+    def __init__(self):
+        RedisBaseInterface.__init__(self)
+
+    def create(self, grass_module):
+        """
+        Add an grass_module to the grass_module database
+
+        Args:
+            grass_module (dict): A GRASS GIS interface description
+
+        Returns:
+            bool:
+            True is success, False if grass_module is already in database
+        """
+
+        grass_module_id = grass_module['id']
+
+        keyname = self.grass_module_id_hash_prefix + grass_module_id
+        exists = self.redis_server.exists(keyname)
+        if exists == 1 or exists is True:
+            return False
+
+        grass_module_bytes = pickle.dumps(grass_module)
+        mapping = {"grass_module_id": grass_module_id,
+                   "grass_module": grass_module_bytes}
+
+        lock = self.redis_server.lock(
+            name="add_grass_module_lock", timeout=1)
+        lock.acquire()
+        # First add the grass_module-id to the grass_module id database
+        self.redis_server.hset(
+            self.grass_module_id_db,
+            grass_module_id,
+            grass_module_id)
+
+        self.redis_server.hset(
+            self.grass_module_id_hash_prefix + grass_module_id,
+            mapping=mapping)
+        lock.release()
+
+        return True
+
+    def read(self, grass_module_id):
+        """Return the grass_module
+
+        HGET grass_module-id grass_module_group
+
+        Args:
+            grass_module_id: The grass_module id
+
+        Returns:
+             str:
+             The grass_module group
+        """
+
+        try:
+            grass_module = pickle.loads(self.redis_server.hget(
+                self.grass_module_id_hash_prefix + grass_module_id,
+                "grass_module"))
+        except Exception:
+            return False
+
+        return grass_module
+
+    def update(self, grass_module_id, grass_module):
+        """Update the grass_module.
+
+        Renaming an entry is not allowed, only existing entries with the
+        same grass_module_id can be updated.
+
+        Args:
+            grass_module_id (str): The grass_module id
+            grass_module (dict): The grass_module as dictionary
+
+        Returns:
+            bool:
+            True is success, False if grass_module is not in the database
+
+        """
+        keyname = self.grass_module_id_hash_prefix + grass_module_id
+        exists = self.redis_server.exists(keyname)
+        if exists == 0 or exists is False:
+            return False
+
+        grass_module_bytes = pickle.dumps(grass_module)
+        mapping = {"grass_module_id": grass_module_id,
+                   "grass_module": grass_module_bytes}
+
+        lock = self.redis_server.lock(
+            name="update_grass_module_lock", timeout=1)
+        lock.acquire()
+
+        self.redis_server.hset(
+            self.grass_module_id_hash_prefix + grass_module_id,
+            mapping=mapping)
+
+        lock.release()
+
+        return True
+
+    # def delete(self, grass_module_id):
+    #     """Remove an grass_module id from the database
+
+    #     Args:
+    #         grass_module_id (str): The grass_module id
+
+    #     Returns:
+    #         bool:
+    #         True is grass_module exists, False otherwise
+    #     """
+    #     exists = self.exists(grass_module_id)
+    #     if exists == 0 or exists is False:
+    #         return False
+
+    #     lock = self.redis_server.lock(
+    #         name="delete_grass_module_lock", timeout=1)
+    #     lock.acquire()
+    #     # Delete the entry from the grass_module id database
+    #     self.redis_server.hdel(self.grass_module_id_db,
+    #                            grass_module_id)
+    #     # Delete the actual grass_module entry
+    #     self.redis_server.delete(
+    #         self.grass_module_id_hash_prefix + grass_module_id)
+    #     lock.release()
+
+    #     return True
+
+    # def list_all_ids(self):
+    #     """
+    #     List all grass_module id's that are in the database
+
+    #     HKEYS on the grass_module id database
+
+    #     Returns:
+    #         list:
+    #         A list of all grass_module ids in the database
+    #     """
+    #     values = []
+    #     list = self.redis_server.hkeys(self.grass_module_id_db)
+    #     for entry in list:
+    #         entry = entry.decode()
+    #         values.append(entry)
+
+    #     return values
+
+    def exists(self, grass_module_id):
+        """Check if the grass_module is in the database
+
+        Args:
+            grass_module_id (str): The grass_module id
+
+        Returns:
+            bool:
+            True is grass_module exists, False otherwise
+        """
+        return self.redis_server.exists(
+            self.grass_module_id_hash_prefix + grass_module_id)
+
+
+# Create the Redis interface instance
+redis_grass_module_interface = RedisActiniaGrassModuleInterface()


### PR DESCRIPTION
The openeo spec wants the full description for the list of all processes. To map this, the parameter `&record=full` was already implemented together with a module filter (eg. `&family=v`) to not run into a timeout. For openeo, the `r`-family is the most interesting one, but is so large that it often runs into a timeout as well so that the openeo-grassgis-driver cannot use the grass gis modules. 
This PR enables a cache for the GRASS GIS modules in the redis db. For requests against `/grass_modules` and `/modules`, all once requested modules are written into the db. When the endpoint to describe one module is requested (`grass_modules/r.slope.aspect`), the interface-description is requested again and the entry in the db will be replaced to allow an api based mechanism to reload the cache, e.g. when a module has a new parameter.
The cache is not yet used when a template description is loaded, which also takes a while, especially when the template uses many grass modules. This can be implemented later if needed.