### PR TITLE
add endpoint to install official GRASS addon

### DIFF
--- a/actinia_module_plugin/api/modules/grass.py
+++ b/actinia_module_plugin/api/modules/grass.py
@@ -38,6 +38,9 @@ from actinia_module_plugin.core.modules.grass import createModuleList
 from actinia_module_plugin.core.modules.grass import createModuleUserList
 from actinia_module_plugin.core.modules.grass import createGrassModule
 from actinia_module_plugin.core.modules.grass import createFullModuleList
+from actinia_module_plugin.core.modules.grass import installGrassAddon
+from actinia_module_plugin.core.modules.accessible_modules_redis_interface \
+    import addGrassAddonToModuleListRedis
 from actinia_module_plugin.model.modules import ModuleList
 from actinia_module_plugin.model.responseModels import \
      SimpleStatusCodeResponseModel
@@ -91,3 +94,21 @@ class DescribeModule(ResourceBase):
                 message='Error looking for module "' + grassmodule + '".'
             )))
             return make_response(res, 404)
+
+    def post(self, grassmodule):
+        """Install an official GRASS GIS Addon.
+        """
+
+        response = installGrassAddon(self, grassmodule)
+        addGrassAddonToModuleListRedis(self, grassmodule)
+
+        if response['status'] == "finished":
+            msg = ('Successfully installed GRASS addon ' + grassmodule + '.')
+            status_code = 201
+        else:
+            msg = ('Error installing GRASS addon ' + grassmodule + '.')
+            status_code = 400
+
+        res = (jsonify(SimpleStatusCodeResponseModel(
+            status=status_code, message=msg)))
+        return make_response(res, status_code)

--- a/actinia_module_plugin/api/modules/grass.py
+++ b/actinia_module_plugin/api/modules/grass.py
@@ -23,9 +23,9 @@ GRASS GIS module viewer
 """
 
 __license__ = "Apache-2.0"
-__author__ = "Anika Bettge, Carmen Tawalika"
-__copyright__ = "Copyright 2019, mundialis"
-__maintainer__ = "Anika Bettge, Carmen Tawalika"
+__author__ = "Anika Weinmann, Carmen Tawalika, Julia Haas"
+__copyright__ = "Copyright 2019 - 2022, mundialis GmbH & Co. KG"
+__maintainer__ = "mundialis GmbH & Co. KG"
 
 
 from flask import jsonify, make_response, request

--- a/actinia_module_plugin/core/modules/accessible_modules_redis_interface.py
+++ b/actinia_module_plugin/core/modules/accessible_modules_redis_interface.py
@@ -48,3 +48,11 @@ def getAccessibleModuleListRedis(self):
                       ["accessible_modules"])
     redis_interface.disconnect()
     return access_modules
+
+
+def addGrassAddonToModuleListRedis(self, grassmodule):
+    """This function adds installed GRASS addon to the user's module list
+    in redis.
+    """
+    self.user.add_accessible_modules([grassmodule, ])
+    self.user.update()

--- a/actinia_module_plugin/core/modules/accessible_modules_redis_interface.py
+++ b/actinia_module_plugin/core/modules/accessible_modules_redis_interface.py
@@ -20,9 +20,9 @@ Accessible Modules Redis Interface
 """
 
 __license__ = "Apache-2.0"
-__author__ = "Anika Weinmann, Carmen Tawalika, Guido Riembauer"
-__copyright__ = "Copyright 2021, mundialis"
-__maintainer__ = "Anika Weinmann, Carmen Tawalika, Guido Riembauer"
+__author__ = "Anika Weinmann, Carmen Tawalika, Guido Riembauer, Julia Haas"
+__copyright__ = "Copyright 2021 - 2022, mundialis GmbH & Co. KG"
+__maintainer__ = "mundialis GmbH & Co. KGr"
 
 from actinia_core.core.redis_user import RedisUserInterface
 from actinia_core.core.common.config import Configuration

--- a/actinia_module_plugin/core/modules/grass.py
+++ b/actinia_module_plugin/core/modules/grass.py
@@ -36,10 +36,29 @@ from actinia_module_plugin.core.modules.processor import run_process_chain
 from actinia_module_plugin.core.modules.parser import ParseInterfaceDescription
 from actinia_module_plugin.model.modules import Module
 from actinia_module_plugin.resources.logging import log
-from actinia_module_plugin.core.modules.grass_modules_redis_interface import \
-     redis_grass_module_interface
+from actinia_module_plugin.core.modules.grass_modules_redis_interface \
+     import redis_grass_module_interface
 from actinia_module_plugin.core.modules.accessible_modules_redis_interface \
      import getAccessibleModuleListRedis
+
+
+def installGrassAddon(self, addon_name):
+    """This function installs an official GRASS addon.
+    """
+    process_chain = {
+        "version": 1,
+        "list": [{
+            "id": "1",
+            "module": "g.extension",
+            "inputs": [{"param": "extension", "value": addon_name}],
+            "flags": "s"
+            }
+        ]
+    }
+
+    response = run_process_chain(self, process_chain)
+
+    return response
 
 
 def createModuleList(self):

--- a/actinia_module_plugin/core/modules/grass.py
+++ b/actinia_module_plugin/core/modules/grass.py
@@ -20,9 +20,9 @@ GRASS GIS module viewer
 """
 
 __license__ = "Apache-2.0"
-__author__ = "Anika Bettge, Carmen Tawalika"
-__copyright__ = "Copyright 2019, mundialis"
-__maintainer__ = "Anika Bettge, Carmen Tawalika"
+__author__ = "Anika Weinmann, Carmen Tawalika, Julia Haas"
+__copyright__ = "Copyright 2019 - 2022, mundialis GmbH & Co. KG"
+__maintainer__ = "mundialis GmbH & Co. KG"
 
 
 import json


### PR DESCRIPTION
The new endpoint is: /grass_modules/<addon name>

Example:
`curl ${AUTH_U} -X POST "${ACTINIA_URL}/grass_modules/r.clip"`

After installation the GRASS module lists in the grassmodules and the user who installed it can use it.

Only official GRASS addons from main branch are allowed.

Addresses #13 

Tests will be added in another PR.
