### PR TITLE
Add module to redis list only if successfully installed

### DIFF
--- a/actinia_module_plugin/api/modules/grass.py
+++ b/actinia_module_plugin/api/modules/grass.py
@@ -100,9 +100,9 @@ class DescribeModule(ResourceBase):
         """
 
         response = installGrassAddon(self, grassmodule)
-        addGrassAddonToModuleListRedis(self, grassmodule)
 
         if response['status'] == "finished":
+            addGrassAddonToModuleListRedis(self, grassmodule)
             msg = ('Successfully installed GRASS addon ' + grassmodule + '.')
             status_code = 201
         else:


### PR DESCRIPTION
Follow-up to #26.

Module is only added to redis list if installed successfully.